### PR TITLE
Adds GQL support

### DIFF
--- a/src/resources/gql_reference.md
+++ b/src/resources/gql_reference.md
@@ -1,0 +1,84 @@
+# GQL — Gramps Query Language Reference
+
+## Syntax
+
+`property operator value` — optionally combined with `and`, `or`, and parentheses.
+
+String values **must be quoted** with double quotes (required for non-ASCII / Cyrillic).
+Numbers and booleans are unquoted.
+
+## Operators
+
+| Operator | Meaning |
+|----------|---------|
+| `=` `!=` | Equality / inequality |
+| `>` `>=` `<` `<=` | Comparison (strings and numbers) |
+| `~` `!~` | Contains / does not contain |
+| *(no operator)* | Boolean — truthy check |
+
+## Special properties
+
+- `length` — length of an array: `media_list.length > 0`
+- `any` / `all` — quantifiers: `event_ref_list.any.ref.get_event.description ~ "Birth"`
+- `get_person`, `get_event`, `get_place`, … — dereference a handle to follow relations
+- `[N]` — array index: `child_ref_list[0].ref`
+
+## Object types
+
+`person`, `family`, `event`, `place`, `citation`, `source`, `repository`, `media`, `note`, `tag`
+
+## Common properties by type
+
+**person** — `gramps_id`, `gender` (0=unknown 1=male 2=female), `private`,
+`primary_name.first_name`, `primary_name.surname_list[0].surname`,
+`birth_ref_index`, `death_ref_index`, `event_ref_list`, `family_list`,
+`parent_family_list`, `media_list`, `note_list`, `tag_list`
+
+**family** — `gramps_id`, `father_handle`, `mother_handle`,
+`child_ref_list`, `child_ref_list.length`, `event_ref_list`, `tag_list`
+
+**event** — `gramps_id`, `type.string`, `description`,
+`date.dateval[2]` (year), `date.modifier` (0=normal),
+`date.sortval`, `place`
+
+**place** — `gramps_id`, `title`, `name.value`, `place_type.string`, `lat`, `long`
+
+**note** — `gramps_id`, `type.string`, `text.string`, `private`
+
+**source** — `gramps_id`, `title`, `author`, `pubinfo`, `abbrev`
+
+**citation** — `gramps_id`, `page`, `confidence`, `source_handle`
+
+**media** — `gramps_id`, `path`, `mime`, `desc`
+
+**repository** — `gramps_id`, `name`, `type.string`
+
+**tag** — `name`, `color`, `priority`
+
+## Examples
+
+```
+# Surname contains "Ivanov" (always quote strings)
+primary_name.surname_list[0].surname ~ "Ivanov"
+
+# First name starts with a Cyrillic prefix
+primary_name.first_name ~ "Ив"
+
+# Private notes mentioning "David"
+private and text.string ~ "David"
+
+# Families with more than 5 children
+child_ref_list.length > 5
+
+# Events after year 1900 with exact date
+date.modifier = 0 and date.dateval[2] > 1900
+
+# People with at least one media reference
+media_list.length > 0
+
+# Objects with a note containing "immigrant"
+note_list.any.get_note.text.string ~ "immigrant"
+
+# Families where all children are female
+child_ref_list.all.ref.get_person.gender = 2
+```

--- a/src/resources/gql_reference.md
+++ b/src/resources/gql_reference.md
@@ -23,6 +23,32 @@ Numbers and booleans are unquoted.
 - `get_person`, `get_event`, `get_place`, … — dereference a handle to follow relations
 - `[N]` — array index: `child_ref_list[0].ref`
 
+## Type fields (`type.value`)
+
+GQL operates on raw Gramps data where **`type.string` is always empty** for built-in types.
+Use `type.value = <integer>` instead. For custom types, `type.string` contains the custom name.
+
+**Common EventType integers:**
+
+| Value | Type |
+|-------|------|
+| 1 | Marriage |
+| 7 | Divorce |
+| 11 | Adopted |
+| 12 | Birth |
+| 13 | Death |
+| 15 | Baptism |
+| 19 | Burial |
+| 21 | Census |
+| 22 | Christening |
+| 28 | Emigration |
+| 30 | Immigration |
+| 37 | Occupation |
+| 42 | Residence |
+| 44 | Will |
+
+> To find a value for an unlisted type: fetch any event of that type and read `type.value`.
+
 ## Object types
 
 `person`, `family`, `event`, `place`, `citation`, `source`, `repository`, `media`, `note`, `tag`
@@ -37,13 +63,13 @@ Numbers and booleans are unquoted.
 **family** — `gramps_id`, `father_handle`, `mother_handle`,
 `child_ref_list`, `child_ref_list.length`, `event_ref_list`, `tag_list`
 
-**event** — `gramps_id`, `type.string`, `description`,
+**event** — `gramps_id`, `type.value` (integer, see table above), `description`,
 `date.dateval[2]` (year), `date.modifier` (0=normal),
 `date.sortval`, `place`
 
-**place** — `gramps_id`, `title`, `name.value`, `place_type.string`, `lat`, `long`
+**place** — `gramps_id`, `title`, `name.value`, `place_type.value`, `lat`, `long`
 
-**note** — `gramps_id`, `type.string`, `text.string`, `private`
+**note** — `gramps_id`, `type.value`, `text.string`, `private`
 
 **source** — `gramps_id`, `title`, `author`, `pubinfo`, `abbrev`
 
@@ -51,7 +77,7 @@ Numbers and booleans are unquoted.
 
 **media** — `gramps_id`, `path`, `mime`, `desc`
 
-**repository** — `gramps_id`, `name`, `type.string`
+**repository** — `gramps_id`, `name`, `type.value`
 
 **tag** — `name`, `color`, `priority`
 
@@ -64,14 +90,17 @@ primary_name.surname_list[0].surname ~ "Ivanov"
 # First name starts with a Cyrillic prefix
 primary_name.first_name ~ "Ив"
 
+# All Birth events
+type.value = 12
+
+# Death events after year 1900 with exact date
+type.value = 13 and date.modifier = 0 and date.dateval[2] > 1900
+
 # Private notes mentioning "David"
 private and text.string ~ "David"
 
 # Families with more than 5 children
 child_ref_list.length > 5
-
-# Events after year 1900 with exact date
-date.modifier = 0 and date.dateval[2] > 1900
 
 # People with at least one media reference
 media_list.length > 0

--- a/src/server.rs
+++ b/src/server.rs
@@ -31,8 +31,10 @@ use rmcp::{
         wrapper::Parameters,
     },
     model::{
-        CallToolRequestParams, CallToolResult, Content, ErrorCode, Implementation, ListToolsResult,
-        PaginatedRequestParams, ServerCapabilities, ServerInfo,
+        CallToolRequestParams, CallToolResult, Content, ErrorCode, Implementation,
+        ListResourcesResult, ListToolsResult, PaginatedRequestParams, RawResource,
+        ReadResourceRequestParams, ReadResourceResult, ResourceContents, ServerCapabilities,
+        ServerInfo,
     },
     service::RequestContext,
     tool, tool_handler, tool_router, ErrorData as McpError, RoleServer, ServerHandler,
@@ -144,16 +146,27 @@ Use page/pagesize to paginate large result sets (default page=1, pagesize=20).")
 
     // ── Get ─────────────────────────────────────────────────────────────────
 
+    #[tool(
+        description = "Get the GQL (Gramps Query Language) reference: operators, \
+special properties, and object property names by type. \
+Call this before writing a gql filter."
+    )]
+    async fn get_gql_reference(&self) -> Result<CallToolResult, McpError> {
+        Ok(CallToolResult::success(vec![Content::text(GQL_REFERENCE)]))
+    }
+
     #[tool(description = "\
 Get genealogy objects. \
-Provide `handle` for a single record, or `gramps_id`/`page`/`pagesize` to browse a collection. \
-For name/text search use the `search` tool instead.")]
+Provide `handle` for a single record, or `gramps_id` / `gql` / `page` / `pagesize` to browse a collection. \
+Use `gql` for structured filtering (call get_gql_reference for syntax). \
+For full-text search use the `search` tool instead.")]
     async fn get_object(
         &self,
         Parameters(GetObjectInput {
             object_type,
             handle,
             gramps_id,
+            gql,
             page,
             pagesize,
         }): Parameters<GetObjectInput>,
@@ -161,13 +174,20 @@ For name/text search use the `search` tool instead.")]
         let endpoint = object_type.as_endpoint();
         let result = if let Some(h) = handle {
             get::get_object_by_handle(&self.client, endpoint, &h).await
-        } else if gramps_id.is_some() || page.is_some() || pagesize.is_some() {
-            get::get_object_collection(&self.client, endpoint, gramps_id.as_deref(), page, pagesize)
-                .await
+        } else if gramps_id.is_some() || gql.is_some() || page.is_some() || pagesize.is_some() {
+            get::get_object_collection(
+                &self.client,
+                endpoint,
+                gramps_id.as_deref(),
+                gql.as_deref(),
+                page,
+                pagesize,
+            )
+            .await
         } else {
             return Ok(CallToolResult::error(vec![Content::text(
                 "Provide `handle` for a single object, \
-                 or `gramps_id` / `page` / `pagesize` to browse a collection.",
+                 or `gramps_id` / `gql` / `page` / `pagesize` to browse a collection.",
             )]));
         };
         result.map_or_else(api_err, ok_json)
@@ -838,12 +858,50 @@ For name/text search use the `search` tool instead.")]
 #[tool_handler]
 impl ServerHandler for GrampsMcpServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
-            .with_instructions("MCP server for accessing genealogy data via the Gramps Web API.")
-            .with_server_info(Implementation::new(
-                "gramps-web-mcp",
-                env!("CARGO_PKG_VERSION"),
-            ))
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .build(),
+        )
+        .with_instructions("MCP server for accessing genealogy data via the Gramps Web API.")
+        .with_server_info(Implementation::new(
+            "gramps-web-mcp",
+            env!("CARGO_PKG_VERSION"),
+        ))
+    }
+
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, McpError> {
+        let resource = RawResource::new("gramps://gql-reference", "gql-reference")
+            .with_title("GQL Reference")
+            .with_description("Gramps Query Language syntax, operators and property reference")
+            .with_mime_type("text/markdown");
+        Ok(ListResourcesResult {
+            resources: vec![rmcp::model::Annotated::new(resource, None)],
+            meta: None,
+            next_cursor: None,
+        })
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, McpError> {
+        if request.uri == "gramps://gql-reference" {
+            return Ok(ReadResourceResult::new(vec![ResourceContents::text(
+                GQL_REFERENCE,
+                "gramps://gql-reference",
+            )]));
+        }
+        Err(McpError::invalid_params(
+            format!("Unknown resource: {}", request.uri),
+            None,
+        ))
     }
 
     // WORKAROUND: Claude Desktop does not recognise JSON Schema draft 2020-12
@@ -908,6 +966,8 @@ impl ServerHandler for GrampsMcpServer {
         }
     }
 }
+
+const GQL_REFERENCE: &str = include_str!("resources/gql_reference.md");
 
 // See the WORKAROUND comment on list_tools above.
 fn fix_schema(v: &mut serde_json::Value) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -157,6 +157,7 @@ Call this before writing a gql filter."
 
     #[tool(description = "\
 Get genealogy objects. \
+`object_type` is always required (person, family, event, place, note, citation, source, media, repository, tag). \
 Provide `handle` for a single record, or `gramps_id` / `gql` / `page` / `pagesize` to browse a collection. \
 Use `gql` for structured filtering (call get_gql_reference for syntax). \
 For full-text search use the `search` tool instead.")]
@@ -171,13 +172,12 @@ For full-text search use the `search` tool instead.")]
             pagesize,
         }): Parameters<GetObjectInput>,
     ) -> Result<CallToolResult, McpError> {
-        let endpoint = object_type.as_endpoint();
         let result = if let Some(h) = handle {
-            get::get_object_by_handle(&self.client, endpoint, &h).await
+            get::get_object_by_handle(&self.client, object_type.as_endpoint(), &h).await
         } else if gramps_id.is_some() || gql.is_some() || page.is_some() || pagesize.is_some() {
             get::get_object_collection(
                 &self.client,
-                endpoint,
+                object_type.as_endpoint(),
                 gramps_id.as_deref(),
                 gql.as_deref(),
                 page,

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -109,6 +109,8 @@ pub struct GetObjectInput {
     pub handle: Option<String>,
     /// Filter by Gramps ID (e.g. "I0001") — returns a collection.
     pub gramps_id: Option<String>,
+    /// GQL filter expression (call get_gql_reference for full syntax).
+    pub gql: Option<String>,
     /// Page number (1-based) for paginated collection results.
     pub page: Option<u32>,
     /// Results per page for collection results (default 20).

--- a/src/tools/get.rs
+++ b/src/tools/get.rs
@@ -62,12 +62,16 @@ pub async fn get_object_collection(
     client: &GrampsClient,
     endpoint: &str,
     gramps_id: Option<&str>,
+    gql: Option<&str>,
     page: Option<u32>,
     pagesize: Option<u32>,
 ) -> Result<serde_json::Value> {
     let mut params: Vec<String> = Vec::new();
     if let Some(id) = gramps_id {
         params.push(format!("gramps_id={}", urlencoding::encode(id)));
+    }
+    if let Some(q) = gql {
+        params.push(format!("gql={}", urlencoding::encode(q)));
     }
     if let Some(p) = page {
         params.push(format!("page={p}"));

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -871,7 +871,7 @@ async fn get_object_collection_pagination_and_gramps_id() {
         .unwrap();
 
     // plain collection browse returns an array
-    let all = get::get_object_collection(client, "people", None, None, None)
+    let all = get::get_object_collection(client, "people", None, None, None, None)
         .await
         .unwrap();
     assert!(
@@ -880,7 +880,7 @@ async fn get_object_collection_pagination_and_gramps_id() {
     );
 
     // pagination: page=1 pagesize=1 must return at most 1 item
-    let page1 = get::get_object_collection(client, "people", None, Some(1), Some(1))
+    let page1 = get::get_object_collection(client, "people", None, None, Some(1), Some(1))
         .await
         .unwrap();
     assert!(page1.is_array());
@@ -894,7 +894,7 @@ async fn get_object_collection_pagination_and_gramps_id() {
         .await
         .unwrap();
     let gramps_id = obj["gramps_id"].as_str().expect("gramps_id missing");
-    let by_id = get::get_object_collection(client, "people", Some(gramps_id), None, None)
+    let by_id = get::get_object_collection(client, "people", Some(gramps_id), None, None, None)
         .await
         .unwrap();
     assert!(by_id.is_array());
@@ -1115,4 +1115,127 @@ async fn search_pagination() {
 
     delete::delete_object(client, "people", &h1).await.unwrap();
     delete::delete_object(client, "people", &h2).await.unwrap();
+}
+
+#[tokio::test]
+async fn gql_filter_people_by_surname() {
+    let fixture = common::TestFixture::new().await;
+    let client = &fixture.client;
+
+    let handle = create::create_person(
+        client,
+        CreatePersonRequest {
+            primary_name: Some(PersonName {
+                surname_list: vec![Surname {
+                    surname: Some("GqlTestSurname".to_string()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let result = get::get_object_collection(
+        client,
+        "people",
+        None,
+        Some(r#"primary_name.surname_list[0].surname ~ "GqlTestSurname""#),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert!(result.is_array(), "gql filter should return an array");
+    let items = result.as_array().unwrap();
+    assert!(
+        items
+            .iter()
+            .any(|p| p["handle"].as_str() == Some(handle.as_str())),
+        "gql filter should find the created person"
+    );
+
+    // gql and pagesize work together
+    let paged = get::get_object_collection(
+        client,
+        "people",
+        None,
+        Some(r#"primary_name.surname_list[0].surname ~ "GqlTestSurname""#),
+        Some(1),
+        Some(1),
+    )
+    .await
+    .unwrap();
+    assert!(paged.is_array(), "gql + pagesize=1 should return an array");
+    assert!(
+        paged.as_array().unwrap().len() <= 1,
+        "pagesize=1 should cap results"
+    );
+
+    delete::delete_object(client, "people", &handle)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn gql_filter_families_by_child_count() {
+    let fixture = common::TestFixture::new().await;
+    let client = &fixture.client;
+
+    let child = create::create_person(client, CreatePersonRequest::default())
+        .await
+        .unwrap();
+
+    let empty_family = create::create_family(client, CreateFamilyRequest::default())
+        .await
+        .unwrap();
+
+    let family_with_child = create::create_family(
+        client,
+        CreateFamilyRequest {
+            child_ref_list: Some(vec![serde_json::json!({"ref": child})]),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let result = get::get_object_collection(
+        client,
+        "families",
+        None,
+        Some("child_ref_list.length > 0"),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert!(result.is_array(), "gql filter should return an array");
+    let items = result.as_array().unwrap();
+    assert!(
+        items
+            .iter()
+            .any(|f| f["handle"].as_str() == Some(family_with_child.as_str())),
+        "family with child should be in results"
+    );
+    assert!(
+        !items
+            .iter()
+            .any(|f| f["handle"].as_str() == Some(empty_family.as_str())),
+        "family without children should not be in results"
+    );
+
+    delete::delete_object(client, "families", &empty_family)
+        .await
+        .unwrap();
+    delete::delete_object(client, "families", &family_with_child)
+        .await
+        .unwrap();
+    delete::delete_object(client, "people", &child)
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
## Summary

Adds GQL (Gramps Query Language) support to `get_object` as a structured filtering option alongside the existing `gramps_id` / `page` / `pagesize` browsing.

- New `gql` parameter on `get_object`, passed through to the underlying Gramps Web API.
- New `get_gql_reference` tool (and matching MCP resource at `gramps://gql-reference`) exposing GQL operators, special properties (`length`, `any`/`all`, handle dereferencing, array indices), per-type field reference, and a table of built-in `EventType` integers. Meant to be called before constructing a filter.

## Status: experimental, not a clean win

In practice the model still struggles to go from a natural-language question to correct GQL syntax, even with the reference available. It burns a fair number of tokens reading the reference and retrying, and still produces invalid filters often enough that I wouldn't point to this as the main selling point yet.

Tried OQL (https://github.com/dsblank/object-ql), which is much better — in contrast to GQL, the LLM grasps the Python-like syntax immediately, without errors. The choice was made in favor OQL.